### PR TITLE
Update styling for image on the Event Details page

### DIFF
--- a/app/(root)/events/[id]/page.tsx
+++ b/app/(root)/events/[id]/page.tsx
@@ -18,6 +18,7 @@ const EventDetails = async ({ params: { id }, searchParams }: SearchParamProps) 
     <>
     <section className="flex justify-center bg-primary-50 bg-dotted-pattern bg-contain">
       <div className="grid grid-cols-1 md:grid-cols-2 2xl:max-w-7xl">
+        <div className="max-w-full">
         <Image 
           src={event.imageUrl}
           alt="hero image"
@@ -25,7 +26,7 @@ const EventDetails = async ({ params: { id }, searchParams }: SearchParamProps) 
           height={1000}
           className="h-full min-h-[300px] object-cover object-center"
         />
-
+      </div>
         <div className="flex w-full flex-col gap-8 p-5 md:p-10">
           <div className="flex flex-col gap-6">
             <h2 className='h2-bold'>{event.title}</h2>


### PR DESCRIPTION
I wrapped the Event image in a div and set the class name to 'max-w-full'. On my deployed version the image was taking up the whole section as a background image. This styled it appropriately for the deployed mobile view.