### PR TITLE
Bugfix: passing initial value for categoryId to Update Event form

### DIFF
--- a/components/shared/EventForm.tsx
+++ b/components/shared/EventForm.tsx
@@ -36,7 +36,8 @@ const EventForm = ({ userId, type, event, eventId }: EventFormProps) => {
     ? { 
       ...event, 
       startDateTime: new Date(event.startDateTime), 
-      endDateTime: new Date(event.endDateTime) 
+      endDateTime: new Date(event.endDateTime),
+      categoryId: event.category._id.toString(),
     }
     : eventDefaultValues;
   const router = useRouter();


### PR DESCRIPTION
The initial value for `cateogryId` was missing in the `EventForm` when updating an event.

![image](https://github.com/adrianhajdin/event_platform/assets/13042947/a53a6882-2f19-4ddb-92bc-9d6583a4fee3)
